### PR TITLE
fix repo_paging=0

### DIFF
--- a/src/GitList/Application.php
+++ b/src/GitList/Application.php
@@ -52,7 +52,7 @@ class Application extends SilexApplication
         $this['show_http_remote'] = $config->get('clone_button', 'show_http_remote');
         $this['use_https'] = $config->get('clone_button', 'use_https');
         $this['ssh_clone_subdir'] = $config->get('clone_button', 'ssh_clone_subdir');
-        $this['repo_paging'] = $config->get('app', 'repo_paging') ? $config->get('app', 'repo_paging') : 10;
+        $this['repo_paging'] = $config->get('app', 'repo_paging') !== false ? $config->get('app', 'repo_paging') : 10;
 
         if (!isset($_SERVER['PHP_AUTH_USER'])) {
             $_SERVER['PHP_AUTH_USER'] = '';


### PR DESCRIPTION
setting `repo_paging` to 0 in config.ini makes GitList use the default value of 10, because php treats 0 as false.

The better fix probably would be to make it possible to override the default "not found" value of `false` in `src/GitList/Config.php`, like that:

```
public function get($section, $option, $default=false)
    {
        if (!array_key_exists($section, $this->data)) {
            return $default;
        }
        ...
```

This way, instead of calling Config::get twice and using the ternary operator, we could simply use `$config->get('app', 'repo_paging', 10)`

I didn't want to be that invasive, but I'd happy to create a PR for that.